### PR TITLE
Rename node settings labels

### DIFF
--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -48,7 +48,7 @@ function Settings() {
         <Box py={theme.spacings.xlarge}>
           <Flex align="center">
             <Label htmlFor="url" style={{width: 120}}>
-              {t('Node address')}
+              {t('Shared node URL')}
             </Label>
             <Input
               id="url"
@@ -61,7 +61,7 @@ function Settings() {
           </Flex>
           <Flex align="center" css={{marginTop: 10}}>
             <Label htmlFor="key" style={{width: 120}}>
-              {`${t('Node api key')} `}
+              {`${t('Shared node api key')} `}
             </Label>
             <Box style={{position: 'relative'}}>
               <PasswordInput


### PR DESCRIPTION
This would help us differentiate Web App settings from Desktop App settings when people send ss in order to help them. They are mixing things up, putting shared node url in Desktop App and stuff like that.